### PR TITLE
Fix runaway squeezelite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyo
 *.pyc
 .DS_Store
+*~

--- a/resources/lib/lmsserver.py
+++ b/resources/lib/lmsserver.py
@@ -306,13 +306,13 @@ class LMSDiscovery(object):
         sock.settimeout(lms_timeout)
         sock.bind(('', 0))
         try:
-            sock.sendto(lms_msg, (lms_ip, lms_port))
+            sock.sendto(lms_msg.encode('utf-8'), (lms_ip, lms_port))
             while True:
                 try:
                     data, server = sock.recvfrom(1024)
                     host, _ = server
                     if data.startswith(b'E'):
-                        port = data.split("\x04")[1]
+                        port = data.split(b'\x04')[1]
                         entries.append({'port': int(port),
                                         'data': data,
                                         'from': server,

--- a/resources/lib/lmsserver.py
+++ b/resources/lib/lmsserver.py
@@ -224,16 +224,17 @@ class LMSServer:
         '''get info from json api'''
         result = {}
         try:
+            #log_msg(f"ToLms: {url}, data: {params}")
             response = requests.post(url, data=json.dumps(params), timeout=20)
             if response and response.content and response.status_code == 200:
                 result = json.loads(response.content.decode('utf-8', 'replace'))
                 if "result" in result:
                     result = result["result"]
             else:
-                log_msg("Invalid or empty response from server - command: %s - server response: %s" %
-                        (cmd, response.status_code))
-        except Exception:
-            log_exception(__name__, "Server is offline or connection error...")
+                log_msg("Invalid or empty response from server - command: xxx - server response: %s" %
+                        (response.status_code))
+        except Exception as exept:
+            log_exception(__name__, f"Server is offline or connection error...{exept}")
 
         #log_msg("%s --> %s" %(params, result))
         return result

--- a/resources/lib/main_service.py
+++ b/resources/lib/main_service.py
@@ -180,9 +180,9 @@ class MainService(threading.Thread):
                 elif self.kodiplayer.playlist.getposition() != self.lmsserver.cur_index:
                     # other track requested
                     self.kodiplayer.is_playing = False # it seems that xbmc.player calls the OnPlayBackStopped function if the play function is called while already playing.
-                    log_msg("other track requested by lms server")
+                    log_msg("index mismatch: other track requested by lms server")
                     self.kodiplayer.play(self.kodiplayer.playlist, startpos=self.lmsserver.cur_index)
-                elif self.lmsserver.status["title"] != xbmc.getInfoLabel("MusicPlayer.Title"):
+                elif self.lmsserver.status["title"].strip() != xbmc.getInfoLabel("MusicPlayer.Title").strip():
                     # monitor if title still matches
                     log_msg("title mismatch - updating playlist...")
                     self.kodiplayer.update_playlist()

--- a/resources/lib/main_service.py
+++ b/resources/lib/main_service.py
@@ -169,7 +169,9 @@ class MainService(threading.Thread):
                 elif not xbmc.getCondVisibility("Player.Paused") and self.lmsserver.mode == "pause":
                     # playback paused
                     log_msg("pause requested by lms server")
-                    self.kodiplayer.pause()
+                    #self.kodiplayer.pause()
+                    # miw: definitively not what we want but doesn't trigger unpause
+                    self.kodiplayer.stop()
                 elif self.kodiplayer.playlist.getposition() != self.lmsserver.cur_index:
                     # other track requested
                     self.kodiplayer.is_playing = False # it seems that xbmc.player calls the OnPlayBackStopped function if the play function is called while already playing.


### PR DESCRIPTION
Hi Jose,

I forked your repo to add the plugin to my kodi installation. However I noticed that squeezelite dies quickly because it cannot claim the audio devices occupied by kodi.
Good thing is that kodi releases the audio device after a (configurable?) timeout.
Thus I added a check that tries to start squeezelite in the `monitor_lms` function. This allows squeezelite to start finally after a minute or so (depending on the `keep audio device alive` setting in kodi). Furthermore added some precautions to make sure there are no zombified processes left over if sqeezelite dies.

This pr contains some other small fixes as well as a crude workaround to the play/pause issue. Now a 'stop' signal is send to kodi if LMS reports 'pause'. In my case it was the only way to stop the player. In all other cases kodi just 'unpaused' and played the track further. It's probably some race condition between LMS and kodi, but I didn't have the time to dig deeper into it.

Most commits are fairly independent, thus you can just cherry-pick what you like.
I hope you'll find it useful.

Btw. I'm running kodi 19.4 on libreelec 10.0.3 on a raspi-3.

Cheers,
Milosz
 